### PR TITLE
Add several highlights to query file

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -10,6 +10,7 @@
   "map"
   "union"
   "resource"
+  "set"
 ] @keyword
 
 (simple_type_name) @type.builtin

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,4 +1,5 @@
 
+
 ; Keywords
 
 [
@@ -8,6 +9,8 @@
   "operation"
   "list"
   "map"
+  "union"
+  "resource"
 ] @keyword
 
 (simple_type_name) @type.builtin
@@ -32,7 +35,13 @@
 
 (number) @number
 (quoted_text) @string
-(comment) @comment
+[
+  (comment)
+  (documentation_comment)
+] @comment
+[ 
+  ("@")
+] @operator
 
 (use_statement
   (absolute_root_shape_id 
@@ -55,11 +64,9 @@
   (identifier) @variable
   (shape_id) @type
 )
-
 (structure_shape_statement
   (identifier) @type.definition
 )
-
 (operation_shape_statement
   (identifier) @type.definition
 )
@@ -67,5 +74,23 @@
   (identifier) @type.definition
 )
 (simple_shape_statement
+  (identifier) @type.definition
+)
+(resource_shape_statement
+  (identifier) @type.definition
+)
+(union_shape_statement
+  (identifier) @type.definition
+)
+(map_shape_statement
+  (identifier) @type.definition
+)
+(service_shape_statement
+  (identifier) @type.definition
+)
+(set_shape_statement
+  (identifier) @type.definition
+)
+(operation_shape_statement
   (identifier) @type.definition
 )

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,5 +1,4 @@
 
-
 ; Keywords
 
 [


### PR DESCRIPTION
This PR adds several new highlights:

* Comments are highlighted when starting with //.
* Mark `union` and `resource` as keywords.
* Highlight `@`.
* Add statements for shapes: `service`, `set`, `operation`, `map`, `union`, `resource`.