### PR TITLE
Make all keywords keywords

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,3 +1,4 @@
+
 ; Preproc
 
 (control_key) @preproc
@@ -11,17 +12,6 @@
 [
   "use"
 ] @include
-
-; Builtins
-
-(primitive) @type.builtin
-[
-  "enum"
-  "intEnum"
-  "list"
-  "map"
-  "set"
-] @type.builtin
 
 ; Fields (Members)
 
@@ -61,16 +51,34 @@
 ; Keywords
 
 [
-  "namespace"
-  "service"
-  "structure"
-  "operation"
-  "union"
-  "resource"
-  "metadata"
   "apply"
   "for"
+  "metadata"
+  "namespace"
   "with"
+  ; shape types
+  "bigDecimal"
+  "bigInteger"
+  "blob"
+  "boolean"
+  "byte"
+  "document"
+  "double"
+  "enum"
+  "float"
+  "intEnum"
+  "integer"
+  "list"
+  "map"
+  "operation"
+  "resource"
+  "service"
+  "set"
+  "short"
+  "string"
+  "structure"
+  "timestamp"
+  "union"
 ] @keyword
 
 ; Literals
@@ -109,4 +117,4 @@
 [
   (comment)
   (documentation_comment)
-] @comment @spell
+] @spell @comment


### PR DESCRIPTION
I'd like to posit that shape definition keywords aren't really builtins, or at the very least shapes like "enum" or "string" should be treated just like "resource" and "services" (a shape is just a shape). Also adding the remaining keywords.

Also, changes the order of captures for comments to satisfy Zed (Metals does the same), otherwise comments show up as if they were plain text.